### PR TITLE
packaging tweaks

### DIFF
--- a/rel/files/riak-cs
+++ b/rel/files/riak-cs
@@ -32,7 +32,7 @@ DEBUG_COMMAND=/usr/sbin/riak-cs-debug
 RUNNER_LOG_DIR={{platform_log_dir}}
 RELX_CONFIG_PATH=${RUNNER_GEN_DIR}/sys.config
 VMARGS_PATH=${RUNNER_GEN_DIR}/vm.args
-PIPE_DIR=/tmp/riak_cs_pipes/    # trailing slash makes it a path for relx
+PIPE_DIR={{pipe_dir}}/    # trailing slash makes it a path for relx
 
 # On first running the sys.config and vm.args will not be a link
 # as cfconfig has not yet been run as a pre_start hook.  If there's no

--- a/rel/pkg/deb/debian/postinst
+++ b/rel/pkg/deb/debian/postinst
@@ -20,6 +20,7 @@ if ! getent passwd riak_cs >/dev/null; then
 fi
 
 chown riak_cs:riak_cs /var/log/riak-cs /etc/riak-cs /var/lib/riak-cs
+chmod 750 /var/log/riak-cs /etc/riak-cs /var/lib/riak-cs
 
 case "$1" in
     configure)

--- a/rel/pkg/deb/debian/postrm
+++ b/rel/pkg/deb/debian/postrm
@@ -25,6 +25,9 @@ case "$1" in
         if [ -d /var/log/riak-cs ]; then
                 rm -r /var/log/riak-cs
         fi
+        if [ -d /var/lib/riak-cs ]; then
+                rm -r /var/lib/riak-cs
+        fi
         if [ -d /var/run/riak-cs ]; then
                 rm -r /var/run/riak-cs
         fi

--- a/rel/pkg/deb/vars.config
+++ b/rel/pkg/deb/vars.config
@@ -40,8 +40,8 @@
 {runner_user,        "riak_cs"}.
 {runner_lib_dir,     "/usr/lib64/riak-cs/lib"}.
 {runner_patch_dir,   "/usr/lib64/riak-cs/lib/patches"}.
-{pipe_dir,           "/tmp/riak-cs/"}.
-{pid_dir,            "/run/riak-cs/"}.
+{pipe_dir,           "/tmp/riak-cs"}.
+{pid_dir,            "/run/riak-cs"}.
 {package_replacement_line, ""}.
 {package_conflicts_line, ""}.
 

--- a/rel/pkg/rpm/specfile
+++ b/rel/pkg/rpm/specfile
@@ -146,7 +146,7 @@ fi
 %{_unitdir}/%{name}.service
 %{_sbindir}/*
 
-%defattr(-,riak_cs,riak_cs)
+%defattr(0750,riak_cs,riak_cs)
 %{_sysconfdir}/riak-cs
 %{_localstatedir}/lib/riak-cs
 %{_localstatedir}/log/riak-cs

--- a/rel/pkg/rpm/specfile
+++ b/rel/pkg/rpm/specfile
@@ -138,18 +138,21 @@ fi
 
 %postun
 %systemd_postun %{name}.service
+rm -f %{_sysconfdir}/riak-cs/riak-cs.conf.new
+rm -rf %{_localstatedir}/lib/riak-cs
+rm -rf %{_localstatedir}/log/riak-cs
 
 %files
 %defattr(-,root,root)
-%dir %{_sysconfdir}/riak-cs
 %{_libdir}/*
 %{_unitdir}/%{name}.service
 %{_sbindir}/*
 
-%defattr(0750,riak_cs,riak_cs)
+%defattr(-,riak_cs,riak_cs)
 %{_sysconfdir}/riak-cs
 %{_localstatedir}/lib/riak-cs
 %{_localstatedir}/log/riak-cs
+
 %config(noreplace) %{_sysconfdir}/riak-cs/*
 
 %clean

--- a/rel/pkg/rpm/vars.config
+++ b/rel/pkg/rpm/vars.config
@@ -40,8 +40,8 @@
 {runner_user,        "riak_cs"}.
 {runner_lib_dir,     "/usr/lib64/riak-cs/lib"}.
 {runner_patch_dir,   "/usr/lib64/riak-cs/lib/patches"}.
-{pipe_dir,           "/tmp/riak-cs/"}.
-{pid_dir,            "/run/riak-cs/"}.
+{pipe_dir,           "/tmp/riak-cs"}.
+{pid_dir,            "/run/riak-cs"}.
 {package_replacement_line, ""}.
 {package_conflicts_line, ""}.
 


### PR DESCRIPTION
* un-hardcode PIPE_DIR path ("/tmp/riak-cs/") in rel/files/riak-cs;
* on purge, clean up generated files in /etc and /lib/riak-cs;
* avoid double trailing / in PID_DIR;
* chmod 750 on /etc (only works in debian).