### PR TITLE
Dockerfile: use ENTRYPOINT instead of CMD.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ FROM debian:latest AS runtime-image
 
 COPY --from=compile-image /usr/src/riak_cs/rel/riak-cs /opt/riak-cs
 
-CMD /opt/riak-cs/bin/riak-cs foreground
+ENTRYPOINT [ "/opt/riak-cs/bin/riak-cs" "foreground" ]


### PR DESCRIPTION
As discussed in #10.
Enables `riak_cs` process to run as PID 1, thus allowing it to receive signals from outside the container.