### PR TITLE
Allow specifying Docker build Erlang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ FROM debian:latest AS runtime-image
 
 COPY --from=compile-image /usr/src/riak_cs/rel/riak-cs /opt/riak-cs
 
-CMD /opt/riak-cs/bin/riak-cs foreground
+ENTRYPOINT [ "/opt/riak-cs/bin/riak-cs" "foreground" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM erlang:25 AS compile-image
+# To override the default Erlang version used in the build, use:
+# $ docker build --build-arg erlang_version=22 ...
+
+ARG erlang_version="25"
+FROM erlang:${erlang_version} AS compile-image
 
 EXPOSE 8080 8085
 


### PR DESCRIPTION
```
docker build --build-arg erlang_version=24 ...
```

Defaults to currently used version on Dockerfile (25).

PR based on #11.